### PR TITLE
Remove unreachable code and add calculator tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -318,8 +318,6 @@ async def embed_upsert(payload: Dict[str, Any] = Body(...)):
     vec = await embed_text(text)
     await qdrant_upsert(pid, vec, {"text": text, **meta})
     return {"ok": True, "id": pid}
-    logger = logging.getLogger("uvicorn")
-    logger.info(f"upload ok: file={file.filename}, chunks={len(chunks)} source={source or 'upload'}")
     
 # ======= API: Query =======
 @app.post("/query", tags=["search"])

--- a/test_calculator.py
+++ b/test_calculator.py
@@ -1,0 +1,12 @@
+import pytest
+from calculator import add, divide
+
+def test_add():
+    assert add(2, 3) == 5
+
+def test_divide():
+    assert divide(10, 2) == 5
+
+def test_divide_by_zero():
+    with pytest.raises(ValueError):
+        divide(1, 0)


### PR DESCRIPTION
## Summary
- remove unreachable logging in embed-upsert endpoint
- add unit tests for calculator utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f5733b5c832883ff91b5abd888a2