### PR TITLE
Improve text extraction utilities

### DIFF
--- a/test.py
+++ b/test.py
@@ -318,8 +318,6 @@ async def embed_upsert(payload: Dict[str, Any] = Body(...)):
     vec = await embed_text(text)
     await qdrant_upsert(pid, vec, {"text": text, **meta})
     return {"ok": True, "id": pid}
-    logger = logging.getLogger("uvicorn")
-    logger.info(f"upload ok: file={file.filename}, chunks={len(chunks)} source={source or 'upload'}")
     
 # ======= API: Query =======
 @app.post("/query", tags=["search"])
@@ -350,54 +348,7 @@ async def query(payload: Dict[str, Any] = Body(...)):
 
 from fastapi import UploadFile, File, Form, Depends, HTTPException
 from fastapi.responses import HTMLResponse
-
-# --- Basit chunk fonksiyonu ---
-def chunk_text(text: str, max_tokens: int = 800, overlap: int = 100):
-    # yaklaşık karakter tabanlı basit bölücü (hızlı ve yeterli)
-    size = max_tokens * 4  # ~ 1 token ≈ 4 char kabulü
-    ov   = overlap * 4
-    out = []
-    i = 0
-    n = len(text)
-    while i < n:
-        j = min(i+size, n)
-        chunk = text[i:j]
-        out.append(chunk.strip())
-        i = j - ov
-        if i < 0: i = 0
-    return [c for c in out if c]
-
-# --- Basit extractor ---
-def extract_text_from_upload(filename: str, data: bytes) -> str:
-    name = filename.lower()
-    if name.endswith(".txt"):
-        return data.decode("utf-8", errors="ignore")
-    if name.endswith(".pdf"):
-        from pypdf import PdfReader
-        from io import BytesIO
-        reader = PdfReader(BytesIO(data))
-        return "\n".join([page.extract_text() or "" for page in reader.pages])
-    if name.endswith(".docx"):
-        import docx
-        from io import BytesIO
-        doc = docx.Document(BytesIO(data))
-        return "\n".join([p.text for p in doc.paragraphs])
-    
-    if name.endswith(".xlsx"):
-        import openpyxl
-        from io import BytesIO
-        wb = openpyxl.load_workbook(BytesIO(data), read_only=True, data_only=True)
-        texts = []
-        for ws in wb.worksheets:
-            for row in ws.iter_rows(values_only=True):
-            # None değerleri temizle ve birleştir
-                line = " ".join(str(cell) for cell in row if cell is not None)
-                if line.strip():
-                    texts.append(line.strip())
-    return "\n".join(texts)
-
-
-    raise ValueError("Desteklenmeyen dosya türü (txt, pdf, docx, xlsx deneyin).")
+from text_utils import chunk_text, extract_text_from_upload
 
 # --- Web: Upload sayfası (GET) ---
 

--- a/test_text_extraction.py
+++ b/test_text_extraction.py
@@ -1,0 +1,11 @@
+import pytest
+
+from text_utils import extract_text_from_upload
+
+def test_extract_text_from_txt():
+    data = b"hello world"
+    assert extract_text_from_upload("file.txt", data) == "hello world"
+
+def test_extract_text_from_unknown_extension():
+    with pytest.raises(ValueError):
+        extract_text_from_upload("file.xyz", b"data")

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+def chunk_text(text: str, max_tokens: int = 800, overlap: int = 100) -> list[str]:
+    """Basit karakter tabanlı bölücü."""
+    size = max_tokens * 4  # ~ 1 token ≈ 4 char kabulü
+    ov = overlap * 4
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        j = min(i + size, n)
+        chunk = text[i:j]
+        out.append(chunk.strip())
+        i = j - ov
+        if i < 0:
+            i = 0
+    return [c for c in out if c]
+
+
+def extract_text_from_upload(filename: str, data: bytes) -> str:
+    """Yüklenen dosyanın içeriğini düz metin olarak döndür."""
+    name = filename.lower()
+    if name.endswith(".txt"):
+        return data.decode("utf-8", errors="ignore")
+    if name.endswith(".pdf"):
+        from pypdf import PdfReader
+        from io import BytesIO
+        reader = PdfReader(BytesIO(data))
+        return "\n".join([page.extract_text() or "" for page in reader.pages])
+    if name.endswith(".docx"):
+        import docx
+        from io import BytesIO
+        doc = docx.Document(BytesIO(data))
+        return "\n".join([p.text for p in doc.paragraphs])
+    if name.endswith(".xlsx"):
+        import openpyxl
+        from io import BytesIO
+        wb = openpyxl.load_workbook(BytesIO(data), read_only=True, data_only=True)
+        texts = []
+        for ws in wb.worksheets:
+            for row in ws.iter_rows(values_only=True):
+                # None değerleri temizle ve birleştir
+                line = " ".join(str(cell) for cell in row if cell is not None)
+                if line.strip():
+                    texts.append(line.strip())
+        return "\n".join(texts)
+    raise ValueError("Desteklenmeyen dosya türü (txt, pdf, docx, xlsx deneyin).")
+


### PR DESCRIPTION
## Summary
- move chunking and text extraction helpers to a shared module
- fix XLSX extraction and raise error for unsupported file types
- clean embed_upsert by removing unreachable logging

## Testing
- `python -m py_compile test.py text_utils.py`
- `pytest test_text_extraction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f8142af4832880cab540a198de59